### PR TITLE
Allow benchmarks to be run with zero configuration by default.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject perforate "0.1.1"
+(defproject perforate "0.1.2-SNAPSHOT"
   :description "Painless benchmarking with Leiningen."
   :dependencies [[org.clojure/clojure "1.4.0-beta5"]
                  [criterium "0.2.0"]]


### PR DESCRIPTION
I changed the lein task a little so that by default `lein perforate` just runs all benchmarks and includes the source paths. Not sure if you'll like it, but makes trying perforate less painful (just create benchmarks and run lein perforate).
