### PR TITLE
Support alternative benchmarks location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pom.xml
 /target/
 .lein-failures
 .lein-deps-sum
+.lein-repl-history

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ benchmarking is done with Hugo Duncan's
 [Criterium](https://github.com/hugoduncan/criterium), which is
 carefully designed to overcome common JVM benchmarking pitfalls.
 
-To use perforate, create a directory in the top level of your project
-called "benchmarks". This directory will be added to the classpath
+To use perforate, create a directory in your project containing 
+perforate benchmarking source (see `simple_bench.clj` below). The 
+default directory location is `benchmarks/`, but you can also specify
+an alternative location in your project i.e. `{:perforate {:source-paths
+["src/bench/clojure"]`. This directory will be added to the classpath
 when perforate runs, and all the specified tests inside it will be
 run. Again, you can think of it as being very similar to the "test/"
 directory used by the test task.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject perforate "0.3.2"
+(defproject perforate "0.4.0-SNAPSHOT"
   :description "Painless benchmarking with Leiningen."
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [criterium "0.4.1"]

--- a/src/perforate/core.clj
+++ b/src/perforate/core.clj
@@ -204,6 +204,17 @@
                              (update-in [:lower-q] first))]]
       (print (csv/write-csv [(map (comp str result) simple-output-keys)])))))
 
+(defn- print-goals [goals]
+  (if (empty? goals)
+    (println (str 
+      "WARNING: No goals found!\n"
+      "Did you place your benchmark sources under \"benchmarks/\" " 
+      "or configure an alternate location as below?\n\n"
+      "   {:perforate {:source-paths [\"src/main/bench/\"]}}\n\n"))
+    (println (apply str 
+      "Perforating the following goals: \n" 
+      (->> goals (map #(-> % meta :name)) (sort) (interpose "\n"))))))
+
 (defn run-benchmarks
   "Given a list of namespaces, runs all the benchmarks they contain and reports
    the results."
@@ -212,6 +223,7 @@
                               (filter #(:perforate/case (meta %))
                                       (vals (ns-interns (the-ns ns))))))
         goals (into #{} (map #(:perforate/goal-for-case (meta %)) cases))
+        _     (print-goals goals)
         goal-case-map (into {} (for [goal goals]
                                  [goal (filter #(= goal
                                                    (:perforate/goal-for-case

--- a/test/leiningen/test/perforate.clj
+++ b/test/leiningen/test/perforate.clj
@@ -1,0 +1,24 @@
+(ns leiningen.test.perforate
+  (:use clojure.test 
+        leiningen.perforate))
+
+(def sample-project-default-sourcepath
+  '(defproject perforate "0.1.0-SNAPSHOT"
+     :description "The next Instagram."
+     :dependencies [[org.clojure/clojure "1.4.0"]]
+     :plugins [[perforate "0.4.0-SNAPSHOT"]]))
+
+(def sample-project-custom-sourcepath
+  '(defproject perforate "0.1.0-SNAPSHOT"
+     :description "The next Tumblr."
+     :dependencies [[org.clojure/clojure "1.4.0"]]
+     :plugins [[perforate "0.4.0-SNAPSHOT"]]
+     :perforate {:source-paths ["src/bench/clojure/"]}))
+
+(deftest test-sourcepaths-configuration 
+  (testing "default sourcepath"
+    (is (= ["benchmarks/"] 
+           (get-benchmark-sourcepaths sample-project-default-sourcepath))))
+  (testing "custom sourcepath"
+    (is (= ["src/bench/clojure/"])
+        (get-benchmark-sourcepaths sample-project-custom-sourcepath))))


### PR DESCRIPTION
I am using a maven-style project layout and want to have my benchmarks under `src/benchmarks/`

I tried adding `:source-paths {"src/benchmarks/" "src/main/clojure/"}` but result was that it exited immediately.

Actually, a warning like "no benchmarks found" would be nice too.
