### PR TITLE
Make sure than cleanup runs last

### DIFF
--- a/src/perforate/core.clj
+++ b/src/perforate/core.clj
@@ -240,12 +240,13 @@
                       (for [goal goals]
                         (let [setup-return (if (:setup @goal)
                                              ((:setup @goal)))
-                              case-results (for [case (get goal-case-map goal)]
-                                             (let [res (run-benchmark
-                                                        case
-                                                        setup-return
-                                                        options-map)]
-                                               [case res]))]
+                              case-results (doall (for [case (get goal-case-map
+                                                                  goal)]
+                                                    (let [res (run-benchmark
+                                                                case
+                                                                setup-return
+                                                                options-map)]
+                                                      [case res])))]
                           (when (:cleanup @goal)
                             (apply (:cleanup @goal) setup-return))
                           case-results))))


### PR DESCRIPTION
The for-comprehension is lazy, so the cleanup function is evaluated before the cases. For example:

``` clj
(ns test-benchmarks
  (:require [perforate.core :refer [defcase defgoal]]))

(defgoal test-benchmark
  "A test benchmark."
  :setup (fn []
           (println "Running setup...")
           [])
  :cleanup (fn [_]
             (println "Running cleanup...")))

(defcase test-benchmark
  :default
  [_]
  (println "Running case..."))
```

produces:

``` zsh
% lein perforate
Benchmarking profiles:  [:dev]
======================
Benchmarking the following goals:
test-benchmark
Running setup...
Running cleanup...
WARNING: Final GC required 2.782969637340718 % of runtime
Running case...
Running case...
Running case...
...
```
